### PR TITLE
feat: Add YAML linting workflow and configuration

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,0 +1,15 @@
+---
+    name: YAML Lint
+    on:
+      pull_request:
+        branches: [main]
+    jobs:
+      lintAllTheThings:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v3
+          - name: yaml-lint
+            uses: ibiqlik/action-yamllint@v3
+            with:
+              file_or_dir: secrets/*.yaml
+              config_file: .github/yamllint.yml

--- a/.github/yamllint.yml
+++ b/.github/yamllint.yml
@@ -1,0 +1,29 @@
+---
+rules:
+  anchors: enable
+  braces: enable
+  brackets: enable
+  colons: enable
+  commas: enable
+  comments:
+    level: warning
+  comments-indentation:
+    level: warning
+  document-end: disable
+  document-start:
+    level: warning
+  empty-lines: enable
+  empty-values: disable
+  float-values: disable
+  hyphens: enable
+  indentation: enable
+  key-duplicates: enable
+  key-ordering: disable
+  line-length: disable
+  new-line-at-end-of-file: enable
+  new-lines: enable
+  octal-values: disable
+  quoted-strings: disable
+  trailing-spaces: enable
+  truthy:
+    level: warning


### PR DESCRIPTION
This commit adds a new YAML linting workflow and configuration files to the repository. The workflow is triggered on pull requests to the main branch and uses the `ibiqlik/action-yamllint` action to lint YAML files in the `secrets` directory. The linting rules are defined in the `.github/yamllint.yml` configuration file.

Signed-off-by: HAHWUL <hahwul@gmail.com>