### PR TITLE
feat: Update secrets detection rules

### DIFF
--- a/secrets/openssh-private-key.yaml
+++ b/secrets/openssh-private-key.yaml
@@ -1,27 +1,20 @@
+---
 id: openssh-private-key
 info:
-  name: "Detect OPENSSH_PRIVATE_KEY"
-  author: 
-    - "hahwul"
+  name: Detect OPENSSH_PRIVATE_KEY
+  author: [hahwul]
   severity: critical
-  description: "Detects the presence of OPENSSH_PRIVATE_KEY in the code"
-  reference:
-    - ""
-
+  description: Detects the presence of OPENSSH_PRIVATE_KEY in the code
+  reference: ['']
 matchers-condition: or
 matchers:
   - type: word
-    patterns:
-      - "OPENSSH_PRIVATE_KEY"
-      - "-----BEGIN OPENSSH PRIVATE KEY-----"
+    patterns: [OPENSSH_PRIVATE_KEY, '-----BEGIN OPENSSH PRIVATE KEY-----']
     condition: or
-
   - type: regex
     patterns:
-      - "OPENSSH_PRIVATE_KEY\\s*=\\s*['\"]?[^'\"]+['\"]?"
-      - "-----BEGIN OPENSSH PRIVATE KEY-----[\\s\\S]*?-----END OPENSSH PRIVATE KEY-----"
+      - OPENSSH_PRIVATE_KEY\s*=\s*['"]?[^'"]+['"]?
+      - '-----BEGIN OPENSSH PRIVATE KEY-----[\s\S]*?-----END OPENSSH PRIVATE KEY-----'
     condition: or
-
 category: secret
-techs:
-  - '*'
+techs: ['*']

--- a/secrets/private-key.yaml
+++ b/secrets/private-key.yaml
@@ -1,27 +1,20 @@
+---
 id: private-key
 info:
-  name: "Detect PRIVATE_KEY"
-  author: 
-    - "hahwul"
+  name: Detect PRIVATE_KEY
+  author: [hahwul]
   severity: critical
-  description: "Detects the presence of PRIVATE_KEY in the code"
-  reference:
-    - ""
-
+  description: Detects the presence of PRIVATE_KEY in the code
+  reference: ['']
 matchers-condition: or
 matchers:
   - type: word
-    patterns:
-      - "PRIVATE_KEY"
-      - "-----BEGIN PRIVATE KEY-----"
+    patterns: [PRIVATE_KEY, '-----BEGIN PRIVATE KEY-----']
     condition: or
-
   - type: regex
     patterns:
-      - "PRIVATE_KEY\\s*=\\s*['\"]?[^'\"]+['\"]?"
-      - "-----BEGIN PRIVATE KEY-----[\\s\\S]*?-----END PRIVATE KEY-----"
+      - PRIVATE_KEY\s*=\s*['"]?[^'"]+['"]?
+      - '-----BEGIN PRIVATE KEY-----[\s\S]*?-----END PRIVATE KEY-----'
     condition: or
-
 category: secret
-techs:
-  - '*'
+techs: ['*']


### PR DESCRIPTION
Update the secrets detection rules for openssh-private-key.yaml and private-key.yaml files. The changes include:
- Updating the name and description of the rules
- Adding additional patterns to match the presence of OPENSSH_PRIVATE_KEY and PRIVATE_KEY
- Updating the author and reference fields

Closes #<issue_number>

Signed-off-by: HAHWUL <hahwul@gmail.com>