### PR TITLE
Add reference URL for Stripe API key rule

### DIFF
--- a/secrets/stripe-api-key.yaml
+++ b/secrets/stripe-api-key.yaml
@@ -5,7 +5,7 @@ info:
   author: [owasp noir team]
   severity: critical
   description: Detects Stripe API keys that could lead to financial risks if exposed
-  reference: ['']
+  reference: ['https://stripe.com/docs/keys']
 matchers-condition: or
 matchers:
   - type: word


### PR DESCRIPTION
Fixes missing reference URL in Stripe API key detection rule.

---
*PR created automatically by Jules for task [8116354071576757789](https://jules.google.com/task/8116354071576757789) started by @hahwul*